### PR TITLE
TAC update

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -614,10 +614,27 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_cart_tax( $value ) {
-		$discount_tax = (float) $this->get_discount_tax();
-		$this->set_prop( 'discount_tax', wc_format_decimal( 0 ) );
-		$value = (float) $value;
-		$this->set_prop( 'cart_tax', wc_format_decimal( $value + $discount_tax ) );
+		$tac_check = false;
+		
+		if(is_admin()){
+			// check if coupon is tac, assign true if tac coupon
+			$coupon_array = $this->get_used_coupons();
+			$tac_check = order_check_if_tac_voucher($coupon_array);
+		} else {
+			$tac_check = WC()->session->get('is_tac_voucher');
+		}
+		
+		if($tac_check){
+			// original
+			$this->set_prop( 'cart_tax', wc_format_decimal( $value ) );
+		} else {
+			// alban
+			$discount_tax = (float) $this->get_discount_tax();
+			$this->set_prop( 'discount_tax', wc_format_decimal( 0 ) );
+			$value = (float) $value;
+			$this->set_prop( 'cart_tax', wc_format_decimal( $value + $discount_tax ) );
+		}
+		// alban
 		$this->set_total_tax( (float) $this->get_cart_tax() + (float) $this->get_shipping_tax() );
 	}
 

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -816,17 +816,23 @@ final class WC_Cart_Totals {
 			do_action( 'woocommerce_calculate_totals', $this->cart );
 		}
 		
-		$i = key($this->cart->taxes);
-		$this->cart->taxes[$i] = $this->cart->get_subtotal_tax();
-
-		// Allow plugins to filter the grand total, and sum the cart totals in case of modifications.
-		$ih_calctotal = apply_filters( 'woocommerce_calculated_total', $this->get_total( 'total' ), $this->cart );
-		$ih_discounted_tax = $this->cart->get_total_tax();
-		$ih_original_tax = $this->cart->get_subtotal_tax();
-		$ih_shipping_tax = $this->cart->get_shipping_tax();
-		$ih_calctotal = round( ( $ih_calctotal - $ih_discounted_tax ) + $ih_original_tax + $ih_shipping_tax, $this->cart->dp );
-		
-		$this->cart->set_total( max( 0, $ih_calctotal ) );
+		if(cart_check_if_tac_voucher($this->cart)){
+			// original
+			$this->cart->set_total( max( 0, apply_filters( 'woocommerce_calculated_total', $this->get_total( 'total' ), $this->cart ) ) );
+		} else {
+			// alban
+			$i = key($this->cart->taxes);
+			$this->cart->taxes[$i] = $this->cart->get_subtotal_tax();
+	
+			// Allow plugins to filter the grand total, and sum the cart totals in case of modifications.
+			$ih_calctotal = apply_filters( 'woocommerce_calculated_total', $this->get_total( 'total' ), $this->cart );
+			$ih_discounted_tax = $this->cart->get_total_tax();
+			$ih_original_tax = $this->cart->get_subtotal_tax();
+			$ih_shipping_tax = $this->cart->get_shipping_tax();
+			$ih_calctotal = round( ( $ih_calctotal - $ih_discounted_tax ) + $ih_original_tax + $ih_shipping_tax, $this->cart->dp );
+			
+			$this->cart->set_total( max( 0, $ih_calctotal ) );
+		}
 	}
 
 	/**

--- a/includes/class-wc-order-item-coupon.php
+++ b/includes/class-wc-order-item-coupon.php
@@ -68,7 +68,22 @@ class WC_Order_Item_Coupon extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_discount_tax( $value ) {
-		$this->set_prop( 'discount_tax', wc_format_decimal( 0 ) );
+		$tac_check = false;
+		
+		$coupon_code = (int) $this->get_code();
+		// first three	digits	coupon,	remove sign if negative,	length
+		$firstThree = (int) substr($coupon_code, $coupon_code < 0 ? 1 : 0, 3);
+		if($firstThree == 903 && strlen($coupon_code) == 9){
+			$tac_check = true;
+		}
+		
+		if($tac_check){
+			// original
+			$this->set_prop( 'discount_tax', wc_format_decimal( $value ) );
+		} else {
+			// alban
+			$this->set_prop( 'discount_tax', wc_format_decimal( 0 ) );
+		}
 	}
 
 	/*

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -123,7 +123,24 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 */
 	public function set_subtotal_tax( $value ) {
 		$this->set_prop( 'subtotal_tax', wc_format_decimal( $value ) );
-		$this->set_prop( 'total_tax', wc_format_decimal( $value ) );
+		
+		$tac_check = false;
+		
+		if(is_admin()){
+			// check if coupon is tac, assign true if tac coupon
+			$coupon_array = $this->get_order()->get_used_coupons();
+			$tac_check = order_check_if_tac_voucher($coupon_array);
+		} else {
+			$tac_check = WC()->session->get('is_tac_voucher');
+		}
+		
+		if($tac_check){
+			// original
+			// nothing
+		} else {
+			// alban
+			$this->set_prop( 'total_tax', wc_format_decimal( $value ) );
+		}
 	}
 
 	/**
@@ -134,6 +151,23 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_total_tax( $value ) {
+		$tac_check = false;
+		
+		if(is_admin()){
+			// check if coupon is tac, assign true if tac coupon
+			$coupon_array = $this->get_order()->get_used_coupons();
+			$tac_check = order_check_if_tac_voucher($coupon_array);
+		} else {
+			$tac_check = WC()->session->get('is_tac_voucher');
+		}
+		
+		if($tac_check){
+			// original
+			$this->set_prop( 'total_tax', wc_format_decimal( $value ) );
+		} else {
+			// alban
+			// nothing
+		}
 	}
 
 	/**
@@ -151,7 +185,24 @@ class WC_Order_Item_Product extends WC_Order_Item {
 		);
 		if ( ! empty( $raw_tax_data['total'] ) && ! empty( $raw_tax_data['subtotal'] ) ) {
 			$tax_data['subtotal'] = array_map( 'wc_format_decimal', $raw_tax_data['subtotal'] );
-			$tax_data['total']    = array_map( 'wc_format_decimal', $raw_tax_data['subtotal'] );
+			
+			$tac_check = false;
+			
+			if(is_admin()){
+				// check if coupon is tac, assign true if tac coupon
+				$coupon_array = $this->get_order()->get_used_coupons();
+				$tac_check = order_check_if_tac_voucher($coupon_array);
+			} else {
+				$tac_check = WC()->session->get('is_tac_voucher');
+			}
+			
+			if($tac_check){
+				// original
+				$tax_data['total']    = array_map( 'wc_format_decimal', $raw_tax_data['total'] );
+			} else {
+				// alban
+				$tax_data['total']    = array_map( 'wc_format_decimal', $raw_tax_data['subtotal'] );
+			}
 
 			// Subtotal cannot be less than total!
 			if ( array_sum( $tax_data['subtotal'] ) < array_sum( $tax_data['total'] ) ) {


### PR DESCRIPTION
Adding functionality for TAC vouchers that have to work like original coupons (discount tax).

This requires the following code to be added to the theme's functions.php:

```php
function check_tac_desc($desc){
	if(strcmp($desc, "TAC - Employee") == 0){
		return true;
	}
	return false;
}
function order_check_if_tac_voucher($coupon_array){
	error_log("" . $coupon_array);
	if(is_array($coupon_array)){
		error_log("is array");
		global $woocommerce;
		foreach($coupon_array as $coupon_code){
		$coupon = new WC_Coupon($coupon_code);
			if(check_tac_desc($coupon->get_description())){
				error_log("is true");
				return true;
			}
			error_log("is false");
			return false;
		}
	}
	error_log("is NOT array");
	return false;
}
function cart_check_if_tac_voucher($cart){
	$coupon_array = $cart->get_applied_coupons();
	global $woocommerce;
	foreach($coupon_array as $coupon_code){
		$coupon = new WC_Coupon($coupon_code);
		if(check_tac_desc($coupon->get_description())){
			WC()->session->set('is_tac_voucher', true);
			return true;
		}
	}
	WC()->session->set('is_tac_voucher', false);
	return false;
}
```